### PR TITLE
Add version for stdlib dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,4 +7,4 @@ description 'Instead of using a seperate resource type for every user, this allo
 project_page 'https://github.com/mthibaut/puppet-users'
 
 ## Add dependencies, if any:
-dependency 'puppetlabs/stdlib'
+dependency 'puppetlabs/stdlib', '>= 3.0.0'


### PR DESCRIPTION
To be able to install the module with librarian-puppet, I needed something like this. 
Before, I got this error : 
``range_requirement?': undefined method `match' for nil:NilClass (NoMethodError)` 

(I don't know if the version number is ok but this is the idea.)
