### PR TITLE
Fix ssh keys

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
-  repositories:
-    "stdlib": "http://github.com/puppetlabs/puppetlabs-stdlib.git"
+  # use the forge modules so we can easily pin to a specific version
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"
   symlinks:
     users: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.swp
+.ruby-version
+.ruby-gemset
 pkg/
 metadata.json
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,11 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
-group :development, :test do
-  gem 'puppetlabs_spec_helper', :require => false
-  gem 'hiera-puppet-helper', '>1.0.0'
-end
-
-if puppetversion = ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', puppetversion, :require => false
-else
-  gem 'puppet', :require => false
-end
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.8.2'
+gem 'puppet-lint', '>= 1.0.0'
+gem 'facter', '>= 1.7.0'
+gem 'rspec'
+gem 'rspec-puppet'
+gem 'rspec-puppet-facts'
+gem 'metadata-json-lint'

--- a/manifests/ssh_authorized_keys.pp
+++ b/manifests/ssh_authorized_keys.pp
@@ -1,15 +1,16 @@
+# define: users::ssh_authorized_keys
 define users::ssh_authorized_keys($user, $hash) {
- 
-    if(!defined(Ssh_authorized_keys[$user])) {
-	ssh_authorized_key { "${user}-${name}" :
-	    ensure   => $hash[$name]['ensure'],
-	    key      => $hash[$name]['key'],
-	    options  => $hash[$name]['options'],
-	    provider => $hash[$name]['provider'],
-	    target   => $hash[$name]['target'],
-	    type     => $hash[$name]['type'],
-	    user     => $user,
-	}
+
+  if(!defined(Ssh_authorized_key["${user}-${name}"])) {
+    ssh_authorized_key { "${user}-${name}" :
+      ensure   => $hash[$name]['ensure'],
+      key      => $hash[$name]['key'],
+      options  => $hash[$name]['options'],
+      provider => $hash[$name]['provider'],
+      target   => $hash[$name]['target'],
+      type     => $hash[$name]['type'],
+      user     => $user,
     }
+  }
 
 }

--- a/spec/defines/users__setup_spec.rb
+++ b/spec/defines/users__setup_spec.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+
+describe 'users::setup', :type => :define do
+
+  describe 'basic user' do
+    let :title do
+      'foo'
+    end
+
+    let :params do
+      {
+        'hash'  => {
+          'foo' => {
+            'uid' => '123',
+          },
+        },
+      }
+    end
+
+    it { should compile }
+    it { should contain_user('foo').with_uid('123') }
+  end
+
+  describe 'user with ssh_authorized_key' do
+    let :title do
+      'foo'
+    end
+
+    let :params do
+      {
+        'hash'  => {
+          'foo' => {
+            'uid' => '123',
+            'ssh_authorized_keys' => {
+              'foo' => {
+                'type' => 'ssh-rsa',
+                'key'  => 'foo_key',
+              }
+            },
+          },
+        },
+      }
+    end
+
+    it { should contain_users__ssh_authorized_keys('foo').with(
+      {
+        'user' => 'foo',
+        'hash' => { 'foo' => {
+            'type' => 'ssh-rsa',
+            'key'  => 'foo_key',
+          }
+        },
+      }
+    ) }
+    it { should contain_ssh_authorized_key('foo-foo') }
+  end
+
+  describe 'user with multiple ssh_authorized_keys' do
+    let :title do
+      'foo'
+    end
+
+    let :params do
+      {
+        'hash'  => {
+          'foo' => {
+            'uid' => '123',
+            'ssh_authorized_keys' => {
+              'foo' => {
+                'type' => 'ssh-rsa',
+                'key'  => 'foo_key',
+              },
+              'bar' => {
+                'type' => 'ssh-rsa',
+                'key'  => 'bar_key',
+              },
+            },
+          },
+        },
+      }
+    end
+
+    it { should contain_users__ssh_authorized_keys('foo') }
+    it { should contain_users__ssh_authorized_keys('bar') }
+    it { should contain_ssh_authorized_key('foo-foo') }
+    it { should contain_ssh_authorized_key('foo-bar') }
+  end
+
+end
+
+# vim: ts=2 sw=2 sts=2 et ai :

--- a/spec/defines/users__ssh_authorized_keys_spec.rb
+++ b/spec/defines/users__ssh_authorized_keys_spec.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+
+describe 'users::ssh_authorized_keys', :type => :define do
+  
+  describe 'basic user with single key' do
+    let :title do
+      'foo'
+    end
+
+    let(:params) {
+      {
+        'user' => 'foo',
+        'hash' => {
+          'foo' => {
+            'type'  => 'ssh-rsa',
+            'key'   => 'foo_key',
+          }
+        },
+      }
+    }
+
+    it { should compile }
+    it { should contain_ssh_authorized_key('foo-foo') }
+  end
+
+end
+
+# vim: ts=2 sw=2 sts=2 et ai :

--- a/spec/defines/users_spec.rb
+++ b/spec/defines/users_spec.rb
@@ -13,16 +13,72 @@ describe 'users', :type => :define do
     end
 
     it { should contain_users('bar') }
-    it { should contain_users__setup('foo').with_hash({"foo"=>{"uid"=>"123"}}) }
+    it { should contain_users__setup('foo').with_hash({'foo'=>{'uid'=>'123'}}) }
     it { should contain_user('foo').with_uid(123) }
   end
 
   describe 'hiera specified simple user hash' do
     let :title do
-      'bar'
+      'baz'
     end
 
-    it { should contain_users('bar') }
-    it { should contain_users__setup('foo').with_hash({"foo"=>{"uid"=>"123"}}) }
+    it { should contain_users('baz') }
+    it { should contain_users__setup('foo').with_hash({'foo'=>{'uid'=>'123'}}) }
   end
+
+  describe 'hiera multilevel hashes' do
+    let :facts do
+      {
+        :clientcert => 'test',
+      }
+    end
+
+    let :title do
+      'test'
+    end
+
+    it { should contain_users('test') }
+    it { should contain_users__setup('foo').with_hash(
+      {
+        'foo' => {'uid' => '123'},
+        'bar' => {'uid' => '321'},
+      }
+    ) }
+    it { should contain_users__setup('bar').with_hash(
+      {
+        'foo' => {'uid' => '123'},
+        'bar' => {'uid' => '321'},
+      }
+    ) }
+    it { should contain_user('bar') }
+  end
+
+  describe 'hiera multilevel hashes - first only' do
+    let :facts do
+      {
+        :clientcert => 'test',
+      }
+    end
+
+    let :title do
+      'test'
+    end
+
+    let :params do
+      {
+        'match' => 'first'
+      }
+    end
+
+    it { should contain_users('test') }
+    it { should_not contain_users__setup('foo') }
+    it { should contain_users__setup('bar').with_hash(
+      {
+        'bar' => {'uid' => '321'},
+      }
+    ) }
+  end
+
 end
+
+# vim: ts=2 sw=2 sts=2 et ai :

--- a/spec/defines/users_spec.rb
+++ b/spec/defines/users_spec.rb
@@ -22,10 +22,6 @@ describe 'users', :type => :define do
       'bar'
     end
 
-    let(:hiera_data) do
-      { 'users_bar' => {'foo' => { 'uid' => '123' } } }
-    end
-
     it { should contain_users('bar') }
     it { should contain_users__setup('foo').with_hash({"foo"=>{"uid"=>"123"}}) }
   end

--- a/spec/fixtures/hiera.yaml
+++ b/spec/fixtures/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: './spec/fixtures/hieradata'
+:hierarchy:
+  - '%{::clientcert}'
+  - 'default'

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -1,6 +1,14 @@
 ---
 
-users_bar:
+users_baz:
+  foo:
+    uid: 123
+
+users_test:
+  foo:
+    uid: 123
+
+users_test2:
   foo:
     uid: 123
 

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -1,0 +1,7 @@
+---
+
+users_bar:
+  foo:
+    uid: 123
+
+# vim: ts=2 sw=2 sts=2 et ai :

--- a/spec/fixtures/hieradata/test.yaml
+++ b/spec/fixtures/hieradata/test.yaml
@@ -1,0 +1,11 @@
+---
+
+users_test:
+  bar:
+    uid: 321
+
+users_test2:
+  bar:
+    uid: 321
+
+# vim: ts=2 sw=2 sts=2 et ai :

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,12 @@
+require 'rspec-puppet-facts'
 require 'puppetlabs_spec_helper/module_spec_helper'
-require 'hiera-puppet-helper'
+
+fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+
+include RspecPuppetFacts
+RSpec.configure do |config|
+  config.formatter = :documentation
+  config.hiera_config = File.join(fixture_path, 'hiera.yaml')
+end
+
+at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
One of the recent versions of puppet does not like the non-existent Ssh_authorized_keys type that is being used to determine if keys should be created. This resolves this issue and adds in rspec test using current (as of the PR) harness
